### PR TITLE
Add support for arguments with spaces via quotes

### DIFF
--- a/src/main/java/modtrekt/commons/core/Messages.java
+++ b/src/main/java/modtrekt/commons/core/Messages.java
@@ -5,7 +5,7 @@ package modtrekt.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_MISSING_COMMAND = "Please enter a command.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";

--- a/src/main/java/modtrekt/commons/util/StringUtil.java
+++ b/src/main/java/modtrekt/commons/util/StringUtil.java
@@ -5,7 +5,9 @@ import static modtrekt.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Helper functions for handling strings.
@@ -96,5 +98,45 @@ public class StringUtil {
         requireNonNull(singular);
         requireNonNull(plural);
         return String.format("%d %s", count, count == 1 ? singular : plural);
+    }
+
+    /**
+     * Python's shlex for Java.
+     * Source: https://stackoverflow.com/questions/1082953/shlex-alternative-for-java
+     */
+    public static String[] shellSplit(CharSequence string) {
+        requireNonNull(string);
+        List<String> tokens = new ArrayList<>();
+        boolean escaping = false;
+        char quoteChar = ' ';
+        boolean quoting = false;
+        int lastCloseQuoteIndex = Integer.MIN_VALUE;
+        StringBuilder current = new StringBuilder();
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (escaping) {
+                current.append(c);
+                escaping = false;
+            } else if (c == '\\' && !(quoting && quoteChar == '\'')) {
+                escaping = true;
+            } else if (quoting && c == quoteChar) {
+                quoting = false;
+                lastCloseQuoteIndex = i;
+            } else if (!quoting && (c == '\'' || c == '"')) {
+                quoting = true;
+                quoteChar = c;
+            } else if (!quoting && Character.isWhitespace(c)) {
+                if (current.length() > 0 || lastCloseQuoteIndex == (i - 1)) {
+                    tokens.add(current.toString());
+                    current = new StringBuilder();
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        if (current.length() > 0 || lastCloseQuoteIndex == (string.length() - 1)) {
+            tokens.add(current.toString());
+        }
+        return tokens.toArray(new String[0]);
     }
 }

--- a/src/main/java/modtrekt/logic/parser/ModtrektParser.java
+++ b/src/main/java/modtrekt/logic/parser/ModtrektParser.java
@@ -9,6 +9,8 @@ import java.util.regex.Pattern;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 
+import modtrekt.commons.core.Messages;
+import modtrekt.commons.util.StringUtil;
 import modtrekt.logic.commands.AddCommand;
 import modtrekt.logic.commands.AddTaskCommand;
 import modtrekt.logic.commands.CdModuleCommand;
@@ -42,15 +44,19 @@ public class ModtrektParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
+        if (userInput.isBlank()) {
+            throw new ParseException(Messages.MESSAGE_MISSING_COMMAND);
+        }
         // devs: Instantiate your commands here by passing it to addCommand() -
         //       you don't need any CommandParser classes anymore.
         JCommander jcommander = JCommander.newBuilder()
                     .addCommand(PrioritizeTaskCommand.COMMAND_WORD, new PrioritizeTaskCommand())
                     .build();
         try {
-            // This takes care of missing or invalid commands, as well as missing or invalid arguments
+            // This takes care of invalid commands, as well as missing or invalid arguments
             // via the ParameterException.
-            jcommander.parse(userInput.strip().split(" "));
+            // Arguments with spaces MUST BE SURROUNDED BY QUOTES.
+            jcommander.parse(StringUtil.shellSplit(userInput.strip()));
             // This cast is safe since we only pass Command objects to jcommander::addCommand.
             return (Command) jcommander.getCommands()
                     .get(jcommander.getParsedCommand())

--- a/src/test/java/modtrekt/commons/util/StringUtilTest.java
+++ b/src/test/java/modtrekt/commons/util/StringUtilTest.java
@@ -1,6 +1,8 @@
 package modtrekt.commons.util;
 
 import static modtrekt.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -140,4 +142,57 @@ public class StringUtilTest {
         assertThrows(NullPointerException.class, () -> StringUtil.getDetails(null));
     }
 
+    // === === ===
+    // SHELL SPLIT
+    @Test
+    public void shellSplit_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.shellSplit(null));
+    }
+
+    @Test
+    public void shellSplit_emptyInput_returnsEmptyArray() {
+        assertEquals(0, StringUtil.shellSplit("").length);
+    }
+
+    @Test
+    public void shellSplit_blankInput_returnsEmptyArray() {
+        assertEquals(0, StringUtil.shellSplit(" \n \r  \r\n ").length);
+    }
+
+    @Test
+    public void shellSplit_validInputsWithoutSpaces_returnsCorrectArray() {
+        assertArrayEquals(new String[]{"test"}, StringUtil.shellSplit("test"));
+        assertArrayEquals(new String[]{"test", "-a"}, StringUtil.shellSplit("test -a"));
+        assertArrayEquals(new String[]{"test", "-a"}, StringUtil.shellSplit("test      -a"));
+        assertArrayEquals(new String[]{"test", "-a", "abc"}, StringUtil.shellSplit("test -a abc"));
+        assertArrayEquals(new String[]{"test", "-a", "abc", "-b", "xyz"}, StringUtil.shellSplit("test -a abc -b xyz"));
+    }
+
+    @Test
+    public void shellSplit_validInputsWithSpaces_returnsCorrectArray() {
+        assertArrayEquals(
+                new String[]{"test", "-a", "abc", "def", "ghi"},
+                StringUtil.shellSplit("test -a abc def ghi")
+        );
+        assertArrayEquals(
+                new String[]{"test", "-a", "abc def ghi"},
+                StringUtil.shellSplit("test -a \"abc def ghi\"")
+        );
+        assertArrayEquals(
+                new String[]{"test", "-a", "abc def ghi", "-b", "w", "x", "y", "z"},
+                StringUtil.shellSplit("test -a \"abc def ghi\" -b w x y z")
+        );
+        assertArrayEquals(
+                new String[]{"test", "-b", "w", "x", "y", "z", "-a", "abc def ghi"},
+                StringUtil.shellSplit("test -b w x y z -a \"abc def ghi\"")
+        );
+        assertArrayEquals(
+                new String[]{"test", "-a", "abc def ghi", "-b", "w x y z"},
+                StringUtil.shellSplit("test -a \"abc def ghi\" -b \"w x y z\"")
+        );
+        assertArrayEquals(
+                new String[]{"test", "-a", "a b  c   d     e\nf"},
+                StringUtil.shellSplit("test -a \"a b  c   d     e\nf\"")
+        );
+    }
 }

--- a/src/test/java/modtrekt/logic/parser/ModtrektParserTest.java
+++ b/src/test/java/modtrekt/logic/parser/ModtrektParserTest.java
@@ -1,6 +1,5 @@
 package modtrekt.logic.parser;
 
-import static modtrekt.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static modtrekt.testutil.Assert.assertThrows;
 import static modtrekt.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import modtrekt.commons.core.Messages;
 import modtrekt.logic.commands.AddTaskCommand;
 import modtrekt.logic.commands.ExitCommand;
 import modtrekt.logic.commands.HelpCommand;
@@ -49,7 +49,7 @@ public class ModtrektParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+        assertThrows(ParseException.class, Messages.MESSAGE_MISSING_COMMAND, ()
             -> parser.parseCommand(""));
     }
 


### PR DESCRIPTION
e.g. `-a "abc def ghi"` gets `abc def ghi` instead of 3 different arguments.

See the test cases for more examples.