### PR TITLE
Deprecate `CommandParser`, `CommandParserBuilder` and `ParsedCommand`

### DIFF
--- a/src/main/java/modtrekt/logic/parser/util/CommandParser.java
+++ b/src/main/java/modtrekt/logic/parser/util/CommandParser.java
@@ -25,7 +25,9 @@ import modtrekt.logic.parser.exceptions.ParseException;
  * along with a list of the missing prefixes.
  * <br>
  * Use CommandParserBuilder to create a CommandParser with a fluent API.
+ * @deprecated Use JCommander instead.
  */
+@Deprecated
 public class CommandParser {
     private final String usageMessage;
     private final Prefix[] requiredPrefixes;

--- a/src/main/java/modtrekt/logic/parser/util/CommandParserBuilder.java
+++ b/src/main/java/modtrekt/logic/parser/util/CommandParserBuilder.java
@@ -8,7 +8,9 @@ import modtrekt.logic.parser.Prefix;
 
 /**
  * Builder for a CommandParser object via a fluent API.
+ * @deprecated Use JCommander instead.
  */
+@Deprecated
 public class CommandParserBuilder {
     private final List<Prefix> requiredPrefixes = new ArrayList<>();
     private final List<Prefix> optionalPrefixes = new ArrayList<>();

--- a/src/main/java/modtrekt/logic/parser/util/ParsedCommand.java
+++ b/src/main/java/modtrekt/logic/parser/util/ParsedCommand.java
@@ -11,7 +11,9 @@ import modtrekt.logic.parser.exceptions.ParseException;
 
 /**
  * ParsedCommand is a wrapper for a command and its multi-map of prefixes to arguments.
+ * @deprecated Use JCommander instead.
  */
+@Deprecated
 public class ParsedCommand {
     private final ArgumentMultimap argMultimap;
 


### PR DESCRIPTION
Use JCommander instead.