### PR TITLE
feat!: command scoping during tokenization

### DIFF
--- a/src/main/java/modtrekt/commons/util/StringUtil.java
+++ b/src/main/java/modtrekt/commons/util/StringUtil.java
@@ -104,7 +104,7 @@ public class StringUtil {
      * Python's shlex for Java.
      * Source: https://stackoverflow.com/questions/1082953/shlex-alternative-for-java
      */
-    public static String[] shellSplit(CharSequence string) {
+    public static List<String> shellSplit(CharSequence string) {
         requireNonNull(string);
         List<String> tokens = new ArrayList<>();
         boolean escaping = false;
@@ -137,6 +137,6 @@ public class StringUtil {
         if (current.length() > 0 || lastCloseQuoteIndex == (string.length() - 1)) {
             tokens.add(current.toString());
         }
-        return tokens.toArray(new String[0]);
+        return tokens;
     }
 }

--- a/src/test/java/modtrekt/commons/util/StringUtilTest.java
+++ b/src/test/java/modtrekt/commons/util/StringUtilTest.java
@@ -151,48 +151,49 @@ public class StringUtilTest {
 
     @Test
     public void shellSplit_emptyInput_returnsEmptyArray() {
-        assertEquals(0, StringUtil.shellSplit("").length);
+        assertEquals(0, StringUtil.shellSplit("").size());
     }
 
     @Test
     public void shellSplit_blankInput_returnsEmptyArray() {
-        assertEquals(0, StringUtil.shellSplit(" \n \r  \r\n ").length);
+        assertEquals(0, StringUtil.shellSplit(" \n \r  \r\n ").size());
     }
 
     @Test
     public void shellSplit_validInputsWithoutSpaces_returnsCorrectArray() {
-        assertArrayEquals(new String[]{"test"}, StringUtil.shellSplit("test"));
-        assertArrayEquals(new String[]{"test", "-a"}, StringUtil.shellSplit("test -a"));
-        assertArrayEquals(new String[]{"test", "-a"}, StringUtil.shellSplit("test      -a"));
-        assertArrayEquals(new String[]{"test", "-a", "abc"}, StringUtil.shellSplit("test -a abc"));
-        assertArrayEquals(new String[]{"test", "-a", "abc", "-b", "xyz"}, StringUtil.shellSplit("test -a abc -b xyz"));
+        assertArrayEquals(new String[]{"test"}, StringUtil.shellSplit("test").toArray());
+        assertArrayEquals(new String[]{"test", "-a"}, StringUtil.shellSplit("test -a").toArray());
+        assertArrayEquals(new String[]{"test", "-a"}, StringUtil.shellSplit("test      -a").toArray());
+        assertArrayEquals(new String[]{"test", "-a", "abc"}, StringUtil.shellSplit("test -a abc").toArray());
+        assertArrayEquals(new String[]{"test", "-a", "abc", "-b", "xyz"},
+                StringUtil.shellSplit("test -a abc -b xyz").toArray());
     }
 
     @Test
     public void shellSplit_validInputsWithSpaces_returnsCorrectArray() {
         assertArrayEquals(
                 new String[]{"test", "-a", "abc", "def", "ghi"},
-                StringUtil.shellSplit("test -a abc def ghi")
+                StringUtil.shellSplit("test -a abc def ghi").toArray()
         );
         assertArrayEquals(
                 new String[]{"test", "-a", "abc def ghi"},
-                StringUtil.shellSplit("test -a \"abc def ghi\"")
+                StringUtil.shellSplit("test -a \"abc def ghi\"").toArray()
         );
         assertArrayEquals(
                 new String[]{"test", "-a", "abc def ghi", "-b", "w", "x", "y", "z"},
-                StringUtil.shellSplit("test -a \"abc def ghi\" -b w x y z")
+                StringUtil.shellSplit("test -a \"abc def ghi\" -b w x y z").toArray()
         );
         assertArrayEquals(
                 new String[]{"test", "-b", "w", "x", "y", "z", "-a", "abc def ghi"},
-                StringUtil.shellSplit("test -b w x y z -a \"abc def ghi\"")
+                StringUtil.shellSplit("test -b w x y z -a \"abc def ghi\"").toArray()
         );
         assertArrayEquals(
                 new String[]{"test", "-a", "abc def ghi", "-b", "w x y z"},
-                StringUtil.shellSplit("test -a \"abc def ghi\" -b \"w x y z\"")
+                StringUtil.shellSplit("test -a \"abc def ghi\" -b \"w x y z\"").toArray()
         );
         assertArrayEquals(
                 new String[]{"test", "-a", "a b  c   d     e\nf"},
-                StringUtil.shellSplit("test -a \"a b  c   d     e\nf\"")
+                StringUtil.shellSplit("test -a \"a b  c   d     e\nf\"").toArray()
         );
     }
 }


### PR DESCRIPTION
### Motivation

#114 and #117 are blocked by JCommander's (intentional) lack of support for global parameter validation, i.e. `add -t` and `add -m` are the same command, but our implementation splits them into two (or more) command classes.

### Changes

This PR introduces a "scope" for commands which are currently "task" (representing `-t`) and "module" (representing `-m`). I have deliberately avoided re-using `-t` and `-m` for scopes to reduce confusion.

This allows us to use command _phrases_ instead of command _words_, e.g. `add task` is the command phrase, whereas previously the command word was `add` and the option `-t` would define the scope.

As such we are free to split commands by their scope and continue to implement them in separate classes, thereby unblocking #114 and #117.

### Example

`add -t` which used to be a single `add` command can be separated into their `AddTaskCommand` and `AddModuleCommand` classes using the command phrases `add task` and `add module` respectively.

Note that you'll need to register both commands with JCommander in `ModtrektParser` independently.

### RFC

I'm leaving this PR open as a draft until the meeting tonight in case we don't go forward with this.

--

**BREAKING CHANGE: this breaks every command which uses `-t` or `-m`.**