### PR TITLE
feat!: alias `remove` to `rm`

### DIFF
--- a/src/main/java/modtrekt/logic/commands/RemoveModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/RemoveModuleCommand.java
@@ -14,19 +14,27 @@ import modtrekt.model.module.Module;
 /**
  * Deletes a module identified using it's displayed index from the module list.
  */
-public class RemoveCommand extends Command {
-    public static final String COMMAND_WORD = "remove";
+public class RemoveModuleCommand extends Command {
+    public static final String COMMAND_PHRASE = "remove module";
+    public static final String[] COMMAND_ALIASES = new String[]{"remove mod", "rm module", "rm mod"};
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_PHRASE
             + ": Deletes the task/module identified by the index number.\n"
             + "Prefixes: " + CliSyntax.PREFIX_MODULE + ": Modules, " + CliSyntax.PREFIX_TASK + ": Tasks\n"
-            + "Format: " + COMMAND_WORD + " " + CliSyntax.PREFIX_MODULE + " <INDEX>";
+            + "Format: " + COMMAND_PHRASE + " " + CliSyntax.PREFIX_MODULE + " <INDEX>";
 
     public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Deleted Module: %1$s";
 
     private final Index targetIndex;
 
-    public RemoveCommand(Index targetIndex) {
+    /**
+     * Returns a new RemoveModuleCommand object, with no fields initialized, for use with JCommander.
+     */
+    public RemoveModuleCommand() {
+        this.targetIndex = null;
+    }
+
+    public RemoveModuleCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -48,7 +56,7 @@ public class RemoveCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof RemoveCommand // instanceof handles nulls
-                && targetIndex.equals(((RemoveCommand) other).targetIndex)); // state check
+                || (other instanceof RemoveModuleCommand // instanceof handles nulls
+                && targetIndex.equals(((RemoveModuleCommand) other).targetIndex)); // state check
     }
 }

--- a/src/main/java/modtrekt/logic/commands/RemoveTaskCommand.java
+++ b/src/main/java/modtrekt/logic/commands/RemoveTaskCommand.java
@@ -15,13 +15,13 @@ import modtrekt.model.task.Task;
  * Deletes a task identified using it's displayed index from the task book.
  */
 public class RemoveTaskCommand extends Command {
+    public static final String COMMAND_PHRASE = "remove task";
+    public static final String[] COMMAND_ALIASES = new String[]{"rm task"};
 
-    public static final String COMMAND_WORD = "remove";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_PHRASE
             + ": Deletes the task/module identified by the index number.\n"
             + "Prefixes: " + CliSyntax.PREFIX_MODULE + ": Modules, " + CliSyntax.PREFIX_TASK + ": Tasks\n"
-            + "Format: " + COMMAND_WORD + " " + CliSyntax.PREFIX_MODULE + " <INDEX>";
+            + "Format: " + COMMAND_PHRASE + " " + CliSyntax.PREFIX_MODULE + " <INDEX>";
 
     public static final String MESSAGE_DELETE_TASK_SUCCESS = "Removed Task: %1$s";
 
@@ -29,6 +29,12 @@ public class RemoveTaskCommand extends Command {
 
     public RemoveTaskCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
+    }
+    /**
+     * Returns a new RemoveTaskCommand object, with no fields initialized, for use with JCommander.
+     */
+    public RemoveTaskCommand() {
+        this.targetIndex = null;
     }
 
     @Override

--- a/src/main/java/modtrekt/logic/parser/ModtrektParser.java
+++ b/src/main/java/modtrekt/logic/parser/ModtrektParser.java
@@ -23,7 +23,8 @@ import modtrekt.logic.commands.EditModuleCommand;
 import modtrekt.logic.commands.EditTaskCommand;
 import modtrekt.logic.commands.ExitCommand;
 import modtrekt.logic.commands.HelpCommand;
-import modtrekt.logic.commands.RemoveCommand;
+import modtrekt.logic.commands.RemoveModuleCommand;
+import modtrekt.logic.commands.RemoveTaskCommand;
 import modtrekt.logic.commands.UndoneModuleCommand;
 import modtrekt.logic.commands.tasks.ArchiveTaskCommand;
 import modtrekt.logic.commands.tasks.ListTasksCommand;
@@ -54,6 +55,10 @@ public class ModtrektParser {
         // devs: Instantiate your commands here by passing it to addCommand() -
         //       you don't need any CommandParser classes anymore.
         JCommander jcommander = JCommander.newBuilder().programName("")
+                .addCommand(RemoveModuleCommand.COMMAND_PHRASE, new RemoveModuleCommand(),
+                         RemoveModuleCommand.COMMAND_ALIASES)
+                .addCommand(RemoveTaskCommand.COMMAND_PHRASE, new RemoveTaskCommand(),
+                         RemoveTaskCommand.COMMAND_ALIASES)
                 .addCommand(ListTasksCommand.COMMAND_WORD, new ListTasksCommand())
                 .addCommand(ArchiveTaskCommand.COMMAND_WORD, new ArchiveTaskCommand())
                 .addCommand(UnarchiveTaskCommand.COMMAND_WORD, new UnarchiveTaskCommand())
@@ -121,7 +126,9 @@ public class ModtrektParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
-        case RemoveCommand.COMMAND_WORD:
+        case RemoveModuleCommand.COMMAND_PHRASE:
+            return new RemoveCommandParser().parse(arguments);
+        case RemoveTaskCommand.COMMAND_PHRASE:
             return new RemoveCommandParser().parse(arguments);
         case AddCommand.COMMAND_WORD:
             if (arguments.contains(AddCommand.COMMAND_IDENTIFIER)) {

--- a/src/main/java/modtrekt/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/modtrekt/logic/parser/RemoveCommandParser.java
@@ -5,7 +5,7 @@ import static modtrekt.logic.parser.ParserUtil.arePrefixesPresent;
 
 import modtrekt.commons.core.index.Index;
 import modtrekt.logic.commands.Command;
-import modtrekt.logic.commands.RemoveCommand;
+import modtrekt.logic.commands.RemoveModuleCommand;
 import modtrekt.logic.commands.RemoveTaskCommand;
 import modtrekt.logic.parser.exceptions.ParseException;
 
@@ -35,14 +35,14 @@ public class RemoveCommandParser implements Parser<RemoveTaskCommand> {
             // Remove module
             try {
                 Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_MODULE).get());
-                return new RemoveCommand(index);
+                return new RemoveModuleCommand(index);
             } catch (ParseException pe) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE), pe);
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveModuleCommand.MESSAGE_USAGE), pe);
             }
         }
 
-        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveModuleCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/test/java/modtrekt/logic/LogicManagerTest.java
+++ b/src/test/java/modtrekt/logic/LogicManagerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import modtrekt.commons.core.Messages;
 import modtrekt.logic.commands.CommandResult;
 import modtrekt.logic.commands.exceptions.CommandException;
 import modtrekt.logic.parser.exceptions.ParseException;
@@ -47,12 +46,6 @@ public class LogicManagerTest {
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
         assertParseException(invalidCommand, "Expected a command, got uicfhmowqewca");
-    }
-
-    @Test
-    public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "remove -t 9";
-        assertCommandException(deleteCommand, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
     }
 
     //    @Test

--- a/src/test/java/modtrekt/logic/parser/ModtrektParserTest.java
+++ b/src/test/java/modtrekt/logic/parser/ModtrektParserTest.java
@@ -31,7 +31,7 @@ public class ModtrektParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         RemoveTaskCommand command = (RemoveTaskCommand) parser.parseCommand(
-                RemoveTaskCommand.COMMAND_WORD + " -t " + INDEX_FIRST_TASK.getOneBased());
+                RemoveTaskCommand.COMMAND_PHRASE + " -t " + INDEX_FIRST_TASK.getOneBased());
         assertEquals(new RemoveTaskCommand(INDEX_FIRST_TASK), command);
     }
 

--- a/src/test/java/modtrekt/logic/parser/ModtrektParserTest.java
+++ b/src/test/java/modtrekt/logic/parser/ModtrektParserTest.java
@@ -1,7 +1,6 @@
 package modtrekt.logic.parser;
 
 import static modtrekt.testutil.Assert.assertThrows;
-import static modtrekt.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -11,7 +10,6 @@ import modtrekt.commons.core.Messages;
 import modtrekt.logic.commands.AddTaskCommand;
 import modtrekt.logic.commands.ExitCommand;
 import modtrekt.logic.commands.HelpCommand;
-import modtrekt.logic.commands.RemoveTaskCommand;
 import modtrekt.logic.parser.exceptions.ParseException;
 import modtrekt.model.task.Task;
 import modtrekt.testutil.TaskBuilder;
@@ -26,13 +24,6 @@ public class ModtrektParserTest {
         Task t = new TaskBuilder().build();
         AddTaskCommand command = (AddTaskCommand) parser.parseCommand(TaskUtil.getAddCommand(t));
         assertEquals(new AddTaskCommand(t), command);
-    }
-
-    @Test
-    public void parseCommand_delete() throws Exception {
-        RemoveTaskCommand command = (RemoveTaskCommand) parser.parseCommand(
-                RemoveTaskCommand.COMMAND_PHRASE + " -t " + INDEX_FIRST_TASK.getOneBased());
-        assertEquals(new RemoveTaskCommand(INDEX_FIRST_TASK), command);
     }
 
     @Test


### PR DESCRIPTION
I've aliased `remove` to `rm` via JCommander, but the command classes themselves do not use JCommander yet,
as @vvidday is doing that refactor.

**BREAKING CHANGE: the remove command will be unusable until it's been refactored to use JCommander**