### PR TITLE
fix symbols in description bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -119,6 +119,7 @@ Examples:
 Adds a task under specific module.
 - User must be within a module page.
 - User may optionally include a deadline for the task by specifying the -d flag along with the deadline in DD/MM/YYYY format.
+- Description of a task can **only** contain American Standard Code for Information Interchange (ASCII) characters
 
 Format: `add task <task> [-d <deadline>]`
 

--- a/src/main/java/modtrekt/model/task/Description.java
+++ b/src/main/java/modtrekt/model/task/Description.java
@@ -16,7 +16,7 @@ public class Description implements Comparable<Description> {
      * The first character of the task must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{ASCII}][\\p{ASCII} ]*";
 
     public final String description;
 


### PR DESCRIPTION
This PR will allow all ASCII characters in descriptions for tasks.