### PR TITLE
feat(ux): module and task pane changes now highlight affected cards

### DIFF
--- a/src/main/java/modtrekt/model/ModelManager.java
+++ b/src/main/java/modtrekt/model/ModelManager.java
@@ -117,7 +117,6 @@ public class ModelManager implements Model {
     public void addTask(Task t) {
         taskBook.addTask(t);
         updateModuleTaskCount(t);
-        updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
     }
 
     @Override
@@ -187,7 +186,6 @@ public class ModelManager implements Model {
     @Override
     public void addModule(Module module) {
         moduleList.addModule(module);
-        updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
     }
 
     @Override

--- a/src/main/java/modtrekt/model/ModelManager.java
+++ b/src/main/java/modtrekt/model/ModelManager.java
@@ -294,7 +294,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Module> getFilteredModuleList() {
-        return filteredModules;
+        return filteredModules.sorted();
     }
 
     @Override

--- a/src/main/java/modtrekt/model/module/ModCode.java
+++ b/src/main/java/modtrekt/model/module/ModCode.java
@@ -7,7 +7,7 @@ import static modtrekt.commons.util.AppUtil.checkArgument;
  * Represents a Module's code in the module list.
  * Guarantees: immutable; is valid as declared in {@link #isValidCode(String)}
  */
-public class ModCode {
+public class ModCode implements Comparable<ModCode> {
 
     public static final String MESSAGE_CONSTRAINTS = "Code should contain alphanumeric characters and no white space";
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
@@ -52,5 +52,10 @@ public class ModCode {
 
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public int compareTo(ModCode that) {
+        return this.value.compareTo(that.value);
     }
 }

--- a/src/main/java/modtrekt/model/module/Module.java
+++ b/src/main/java/modtrekt/model/module/Module.java
@@ -1,12 +1,20 @@
 package modtrekt.model.module;
 
+import java.util.Comparator;
 import java.util.Objects;
 
 /**
  * Represents a module in the module list.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Module {
+public class Module implements Comparable<Module> {
+    public static final Comparator<Module> SELECTION_COMPARATOR =
+            Comparator.comparing(Module::getIsCurrentModule).reversed(); // selected module first
+    public static final Comparator<Module> COMPLETION_COMPARATOR =
+            Comparator.comparing(Module::isDone); // completed module first
+    public static final Comparator<Module> CODE_COMPARATOR =
+            Comparator.comparing(Module::getCode); // lexicographical sort by mod code
+
     private final ModCode code;
     private final ModName name;
     private final ModCredit credits;
@@ -170,5 +178,13 @@ public class Module {
     @Override
     public String toString() {
         return getName() + ", Code: " + getCode() + ", Credits: " + getCredits() + (isDone ? "(DONE)" : "");
+    }
+
+    @Override
+    public int compareTo(Module o) {
+        return SELECTION_COMPARATOR
+                .thenComparing(COMPLETION_COMPARATOR)
+                .thenComparing(CODE_COMPARATOR)
+                .compare(this, o);
     }
 }

--- a/src/main/java/modtrekt/ui/modules/ModuleListPanel.java
+++ b/src/main/java/modtrekt/ui/modules/ModuleListPanel.java
@@ -2,6 +2,7 @@ package modtrekt.ui.modules;
 
 import java.util.logging.Logger;
 
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -28,6 +29,11 @@ public class ModuleListPanel extends UiPart<Region> {
         super(FXML);
         moduleListView.setItems(moduleList);
         moduleListView.setCellFactory(listView -> new ModuleListPanelCell());
+        moduleList.addListener((ListChangeListener<? super Module>) (e) -> {
+            if (moduleList.size() > 0) {
+                moduleListView.scrollTo(0);
+            }
+        });
     }
 
     /**

--- a/src/main/java/modtrekt/ui/modules/ModuleListPanel.java
+++ b/src/main/java/modtrekt/ui/modules/ModuleListPanel.java
@@ -29,11 +29,29 @@ public class ModuleListPanel extends UiPart<Region> {
         super(FXML);
         moduleListView.setItems(moduleList);
         moduleListView.setCellFactory(listView -> new ModuleListPanelCell());
-        moduleList.addListener((ListChangeListener<? super Module>) (e) -> {
-            if (moduleList.size() > 0) {
-                moduleListView.scrollTo(0);
+        moduleList.addListener((ListChangeListener<? super Module>) this::handleChange);
+    }
+
+    /**
+     * Handles change in the list of modules by highlighting the ModuleCard addition to the list, if any.
+     */
+    private void handleChange(ListChangeListener.Change<? extends Module> change) {
+        moduleListView.getSelectionModel().clearSelection();
+        moduleListView.getFocusModel().focus(-1);
+        while (change.next()) {
+            logger.fine(change.toString());
+            if (!moduleListView.getItems().isEmpty() && change.wasAdded() && change.getAddedSize() == 1) {
+                // We only care about additions of size 1 because those are the only kinds of changes we
+                // should set selection and focus to (multi-selection doesn't make sense because filtering (e.g. ls -a)
+                // affects the entire list).
+                // We ignore removals because there's nothing to focus and select after it's removed.
+                int changeIndex = change.getFrom();
+                moduleListView.scrollTo(changeIndex);
+                moduleListView.getSelectionModel().select(changeIndex);
+                moduleListView.getFocusModel().focus(changeIndex);
+                return;
             }
-        });
+        }
     }
 
     /**

--- a/src/main/java/modtrekt/ui/tasks/TaskListPanel.java
+++ b/src/main/java/modtrekt/ui/tasks/TaskListPanel.java
@@ -2,6 +2,7 @@ package modtrekt.ui.tasks;
 
 import java.util.logging.Logger;
 
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -28,6 +29,29 @@ public class TaskListPanel extends UiPart<Region> {
         super(FXML);
         taskListView.setItems(taskList);
         taskListView.setCellFactory(listView -> new TaskListViewCell());
+        taskList.addListener((ListChangeListener<? super Task>) this::handleChange);
+    }
+
+    /**
+     * Handles change in the list of modules by highlighting the TaskCard addition to the list, if any.
+     */
+    private void handleChange(ListChangeListener.Change<? extends Task> change) {
+        taskListView.getSelectionModel().clearSelection();
+        taskListView.getFocusModel().focus(-1);
+        while (change.next()) {
+            logger.fine(change.toString());
+            if (!taskListView.getItems().isEmpty() && change.wasAdded() && change.getAddedSize() == 1) {
+                // We only care about additions of size 1 because those are the only kinds of changes we
+                // should set selection and focus to (multi-selection doesn't make sense because filtering (e.g. ls -a)
+                // affects the entire list).
+                // We ignore removals because there's nothing to focus and select after it's removed.
+                int changeIndex = change.getFrom();
+                taskListView.scrollTo(changeIndex);
+                taskListView.getSelectionModel().select(changeIndex);
+                taskListView.getFocusModel().focus(changeIndex);
+                return;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
The selected module gets moved to the top after a `cd`, and done modules go to the bottom (useful for `ls`), and whenever there's a non-removal change to the panes, the relevant card will be highlighted and scrolled to:

https://user-images.githubusercontent.com/50949210/198285320-ec8dfb83-145a-456a-b5c2-96f55c425203.mov

Also fixes the bugs which reveal all mods/tasks after adding one.