### PR TITLE
fix null pointer exception for non-existent mod codes

### DIFF
--- a/src/main/java/modtrekt/logic/commands/AddModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/AddModuleCommand.java
@@ -74,7 +74,9 @@ public class AddModuleCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        if (model.hasModuleWithModCode(modCode) || model.hasModuleWithModCode(modCode)) {
+
+        /* Module equality validated only via modCode, as some modules have the same name. */
+        if (model.hasModuleWithModCode(modCode)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
         }
 

--- a/src/main/java/modtrekt/logic/parser/module/ModuleParser.java
+++ b/src/main/java/modtrekt/logic/parser/module/ModuleParser.java
@@ -45,6 +45,8 @@ public class ModuleParser {
             /* A non-200 response code indicates that our request has failed, hence we use fallback data files. */
             if (response.statusCode() != 200) {
                 try {
+                    /* The case where the module does not exist is also handled here, as null is returned if no such
+                    * code exists. */
                     return parseModuleFromFile(code);
                 } catch (IOException e) {
                     /* Error reading data file with code */
@@ -77,6 +79,9 @@ public class ModuleParser {
     private static Module parseModuleFromFile(String code) throws IOException {
         JsonNode fallbackData = new ObjectMapper().readValue(
                 FileUtil.readFromFile(backupFilePath), JsonNode.class);
+        if (!(fallbackData.has(code))) {
+            return null;
+        }
         String moduleData = fallbackData.get(code).toString();
         JsonNode moduleNode = new ObjectMapper().readValue(moduleData, JsonNode.class);
         String moduleName = moduleNode.get("title").toString();


### PR DESCRIPTION
Fixed via checking the validity of code in the fallback data file, so a 404 response is returned when no data is found for that code, and the program defaults to checking the fallback file, returning null if no such code is found in our fallback file.