### PR TITLE
FIx behaviour where error was not thrown when date is invalid

### DIFF
--- a/src/main/java/modtrekt/logic/parser/ParserUtil.java
+++ b/src/main/java/modtrekt/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.stream.Stream;
 
 import modtrekt.commons.core.index.Index;
@@ -59,7 +60,8 @@ public class ParserUtil {
         requireNonNull(date);
         String trimmedDate = date.trim();
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-M-d");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-M-d")
+                    .withResolverStyle(ResolverStyle.STRICT);
             return LocalDate.parse(trimmedDate, formatter);
         } catch (DateTimeParseException exception) {
             throw new ParseException("Invalid date, date must be in YYYY-MM-DD format");

--- a/src/main/java/modtrekt/logic/parser/converters/DeadlineConverter.java
+++ b/src/main/java/modtrekt/logic/parser/converters/DeadlineConverter.java
@@ -3,6 +3,7 @@ package modtrekt.logic.parser.converters;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
@@ -15,8 +16,14 @@ public class DeadlineConverter implements IStringConverter<LocalDate> {
     public LocalDate convert(String value) {
         String trimmedDate = value.trim();
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-M-d");
-            return LocalDate.parse(trimmedDate, formatter);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-M-d")
+                    .withResolverStyle(ResolverStyle.STRICT);
+            LocalDate date = LocalDate.parse(trimmedDate, formatter);
+            // "uuuu" allows years with negative values
+            if (date.getYear() < 0) {
+                throw new ParameterException("Invalid date, date must be in YYYY-MM-DD format");
+            }
+            return date;
         } catch (DateTimeParseException exception) {
             throw new ParameterException("Invalid date, date must be in YYYY-MM-DD format");
         }

--- a/src/main/java/modtrekt/storage/JsonAdaptedTask.java
+++ b/src/main/java/modtrekt/storage/JsonAdaptedTask.java
@@ -2,6 +2,7 @@ package modtrekt.storage;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,7 +83,8 @@ public class JsonAdaptedTask {
         if (dueDate == null) {
             return new Task(modelDescription, modCode, isDone, modelPriority);
         }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-M-d");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-M-d")
+                .withResolverStyle(ResolverStyle.STRICT);
         LocalDate dueDateObj = LocalDate.parse(dueDate, formatter);
         return new Deadline(modelDescription, modCode, dueDateObj, isDone, modelPriority);
     }

--- a/src/test/java/modtrekt/logic/parser/converters/DeadlineConverterTest.java
+++ b/src/test/java/modtrekt/logic/parser/converters/DeadlineConverterTest.java
@@ -1,0 +1,48 @@
+package modtrekt.logic.parser.converters;
+
+import static modtrekt.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import com.beust.jcommander.ParameterException;
+
+class DeadlineConverterTest {
+
+    private final DeadlineConverter converter = new DeadlineConverter();
+
+    // Out of bounds - Does not follow YYYY-MM-DD format
+    @Test
+    public void convert_outOfBounds_throws() {
+        assertThrows(ParameterException.class, () -> converter.convert("-2022-01-01"));
+        assertThrows(ParameterException.class, () -> converter.convert("99999-01-01"));
+        assertThrows(ParameterException.class, () -> converter.convert("2022-112-01"));
+        assertThrows(ParameterException.class, () -> converter.convert("2022-01-112"));
+    }
+
+    // Valid format, dates do not exist
+    @Test
+    public void convert_invalidDates_throws() {
+        // 31 dates that do not exist
+        assertThrows(ParameterException.class, () -> converter.convert("2022-11-31"));
+        assertThrows(ParameterException.class, () -> converter.convert("2022-09-31"));
+        // Non-leap year >28 Feb
+        assertThrows(ParameterException.class, () -> converter.convert("2021-02-29"));
+        assertThrows(ParameterException.class, () -> converter.convert("2022-02-29"));
+        assertThrows(ParameterException.class, () -> converter.convert("2023-02-29"));
+    }
+
+    @Test
+    public void convert_edgeCasesValidDates_returnsDate() throws ParameterException {
+        // Leap year >28 Feb
+        LocalDate date = converter.convert("2016-02-29");
+        assertEquals(date.getDayOfMonth(), 29);
+        LocalDate date2 = converter.convert("2020-02-29");
+        assertEquals(date2.getDayOfMonth(), 29);
+        LocalDate date3 = converter.convert("2024-02-29");
+        assertEquals(date3.getDayOfMonth(), 29);
+    }
+
+}


### PR DESCRIPTION
Fixes #172 

Also worth considering - should we restrict dates to >= current year? Not sure if it may be considered a bug that we can set deadlines to be year 100, for example.