### PR TITLE
Revert changes that prevented cding into done module

### DIFF
--- a/src/main/java/modtrekt/logic/commands/CdModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/CdModuleCommand.java
@@ -5,7 +5,6 @@ import com.beust.jcommander.Parameter;
 import modtrekt.logic.commands.exceptions.CommandException;
 import modtrekt.model.Model;
 import modtrekt.model.module.ModCode;
-import modtrekt.model.module.Module;
 
 /**
  * Changes the current module that is shown to the user.
@@ -49,10 +48,6 @@ public class CdModuleCommand extends Command {
             if (!model.hasModuleWithModCode(moduleCode)) {
                 throw new CommandException(String.format("Module code %s does not exist.",
                         moduleCode));
-            }
-            Module previousModule = model.parseModuleFromCode(moduleCode);
-            if (previousModule.isDone()) {
-                throw new CommandException("Cannot cd into a module that is already marked as done.");
             }
             model.setCurrentModule(moduleCode);
             return new CommandResult(String.format("Changed current module to %s!", moduleCode));

--- a/src/test/java/modtrekt/logic/commands/CdModuleCommandTest.java
+++ b/src/test/java/modtrekt/logic/commands/CdModuleCommandTest.java
@@ -20,9 +20,9 @@ public class CdModuleCommandTest {
     }
 
     @Test
-    public void cd_doneModule_throws() {
+    public void cd_doneModule_returnsTrue() throws CommandException {
         CdModuleCommand command = CdModuleCommandBuilder.build("CS2103");
-        assertThrows(CommandException.class, () -> command.execute(new ModelHasModuleAndModuleIsDone()));
+        command.execute(new ModelHasModuleAndModuleIsDone());
     }
 
     @Test


### PR DESCRIPTION
As discussed, we will be reverting the changes made in #213 as it changes module behaviour

The 'bug' in #187 is not really a bug, since it does follow the UG specifications - the issue of the module "not showing" is because the user executed the `list mod` command, whose function is to _hide_ modules that are marked as `done`. The program was working as expected