### PR TITLE
update module code related error messages to specify requirements

### DIFF
--- a/src/main/java/modtrekt/commons/core/Messages.java
+++ b/src/main/java/modtrekt/commons/core/Messages.java
@@ -8,5 +8,4 @@ public class Messages {
     public static final String MESSAGE_MISSING_COMMAND = "Please enter a command.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
-    public static final String MESSAGE_INVALID_MODULE_CODE_TO_REMOVE = "The module code provided is invalid";
 }

--- a/src/main/java/modtrekt/logic/commands/CdModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/CdModuleCommand.java
@@ -11,7 +11,8 @@ import modtrekt.model.module.ModCode;
  */
 public class CdModuleCommand extends Command {
     public static final String COMMAND_WORD = "cd";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " <module code>: cds into specified module.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " <alphanumeric mod code of 6-9 characters>: "
+            + "cds into specified module.\n"
             + COMMAND_WORD + " ..: cds out of current module.";
 
     @Parameter(description = "<module code>: the module code to cd into, or '..' to cd out.",

--- a/src/main/java/modtrekt/logic/commands/DoneModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/DoneModuleCommand.java
@@ -19,7 +19,7 @@ public class DoneModuleCommand extends Command {
     public static final String COMMAND_WORD = "done module";
     public static final String COMMAND_ALIAS = "done mod";
 
-    @Parameter(description = "<module code>",
+    @Parameter(description = "<alphanumeric mod code of 6-9 characters>",
             required = true, converter = ModCodeConverter.class)
 
     private ModCode moduleCode;

--- a/src/main/java/modtrekt/logic/commands/EditModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/EditModuleCommand.java
@@ -30,7 +30,7 @@ public class EditModuleCommand extends Command {
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Module successfully edited: %1$s";
 
-    @Parameter(description = "<module code>", required = true,
+    @Parameter(description = "<alphanumeric mod code of 6-9 characters>", required = true,
             converter = ModCodeConverter.class)
     private ModCode targetModCode;
 

--- a/src/main/java/modtrekt/logic/commands/RemoveModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/RemoveModuleCommand.java
@@ -2,11 +2,8 @@ package modtrekt.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
 import com.beust.jcommander.Parameter;
 
-import modtrekt.commons.core.Messages;
 import modtrekt.logic.commands.exceptions.CommandException;
 import modtrekt.logic.parser.CliSyntax;
 import modtrekt.logic.parser.converters.ModCodeConverter;
@@ -28,7 +25,7 @@ public class RemoveModuleCommand extends Command {
 
     public static final String MESSAGE_DELETE_MODULE_SUCCESS = "I successfully deleted the module: %1$s!";
 
-    @Parameter(description = "module code", required = true,
+    @Parameter(description = "<alphanumeric mod code of 6-9 characters>", required = true,
         converter = ModCodeConverter.class)
     private ModCode code;
 
@@ -44,12 +41,9 @@ public class RemoveModuleCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Module> lastShownList = model.getFilteredModuleList();
-
         if (!(model.hasModuleWithModCode(code))) {
-            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_CODE_TO_REMOVE);
+            throw new CommandException(String.format("Module code %s does not exist.", code));
         }
-
         Module moduleToDelete = model.parseModuleFromCode(code);
         model.deleteModule(moduleToDelete);
         model.deleteTasksOfModule(moduleToDelete);

--- a/src/main/java/modtrekt/logic/commands/UndoneModuleCommand.java
+++ b/src/main/java/modtrekt/logic/commands/UndoneModuleCommand.java
@@ -19,7 +19,7 @@ public class UndoneModuleCommand extends Command {
     public static final String COMMAND_WORD = "undone module";
     public static final String COMMAND_ALIAS = "undone mod";
 
-    @Parameter(description = "<module code>",
+    @Parameter(description = "<alphanumeric mod code of 6-9 characters>",
             required = true, converter = ModCodeConverter.class)
 
     private ModCode moduleCode;


### PR DESCRIPTION
Updates error message to be more specific, i.e. to specify if the module code does not exist in the list, and also specifies the requirement for it the be 6-9 characters and only contain alphanumeric characters.

To test, try out:

`remove/done/undone/edit mod CS1283213213`
`remove/done/undone mod CS12832` without a module with code CS12832 in the list
`cd CS1283213213`
`cd CS12832` without a module with code CS12832 in the list



