### PR TITLE
Fix error messages involving non-numeric indices

### DIFF
--- a/src/main/java/modtrekt/commons/core/index/Index.java
+++ b/src/main/java/modtrekt/commons/core/index/Index.java
@@ -9,18 +9,19 @@ package modtrekt.commons.core.index;
  * convert it back to an int if the index will not be passed to a different component again.
  */
 public class Index {
-    private int zeroBasedIndex;
+    private final int zeroBasedIndex;
+    private final int enteredIndex;
 
     /**
      * Index can only be created by calling {@link Index#fromZeroBased(int)} or
      * {@link Index#fromOneBased(int)}.
      */
-    private Index(int zeroBasedIndex) {
+    private Index(int zeroBasedIndex, int enteredIndex) {
         if (zeroBasedIndex < 0) {
             throw new IndexOutOfBoundsException();
         }
-
         this.zeroBasedIndex = zeroBasedIndex;
+        this.enteredIndex = enteredIndex;
     }
 
     public int getZeroBased() {
@@ -35,14 +36,14 @@ public class Index {
      * Creates a new {@code Index} using a zero-based index.
      */
     public static Index fromZeroBased(int zeroBasedIndex) {
-        return new Index(zeroBasedIndex);
+        return new Index(zeroBasedIndex, zeroBasedIndex);
     }
 
     /**
      * Creates a new {@code Index} using a one-based index.
      */
     public static Index fromOneBased(int oneBasedIndex) {
-        return new Index(oneBasedIndex - 1);
+        return new Index(oneBasedIndex - 1, oneBasedIndex);
     }
 
     @Override
@@ -50,5 +51,10 @@ public class Index {
         return other == this // short circuit if same object
                 || (other instanceof Index // instanceof handles nulls
                 && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(enteredIndex);
     }
 }

--- a/src/main/java/modtrekt/logic/parser/converters/IndexConverter.java
+++ b/src/main/java/modtrekt/logic/parser/converters/IndexConverter.java
@@ -12,9 +12,23 @@ import modtrekt.commons.util.StringUtil;
 public class IndexConverter implements IStringConverter<Index> {
     @Override
     public Index convert(String value) {
+        if (!isValidInteger(value)) {
+            throw new ParameterException(
+                    "Syntax error. If your command arguments contain spaces, surround them with quotes."
+            );
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(value)) {
             throw new ParameterException("The index must be a non-zero unsigned integer.");
         }
         return Index.fromOneBased(Integer.parseInt(value));
+    }
+
+    private boolean isValidInteger(String value) {
+        try {
+            Integer.parseInt(value);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Currently, a command that requires an index as a main argument will display an incorrect error message if any excess value is not a valid argument (#171, #192).

For example, the command `edit task 1 -ds foo bar` will display "The index must be a non-zero unsigned integer.", which is clearly incorrect, because the value "1" is a valid index.

This PR fixes this, with the correct error message "Too many values provided. If your values contain spaces, surround them with quotes." displayed.

### Commands for Manual Testing

- `edit task 1 -ds foo bar`
- `edit task 1 -ds foo -invalid`
- `remove task 1 foo`, `rm task 1 foo`
- `done task 1 foo`, `undone task 1 foo`


### Other Changes

- Implemented `Index::toString` to facilitate index testing based on whatever index was entered.
- SLAP`ModtrektParser` harder.